### PR TITLE
7291: implements selenium/firefox sanity check

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -443,7 +443,7 @@ EOF
 fi
 
 # Ensure we have the newest selenium-webdriver
-gem update selenium-webdriver
+gem install selenium-webdriver
 
 # If DISPLAY is unset, there is no way selenium/firefox could work
 if [ -n "${DISPLAY}" ]

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -442,6 +442,36 @@ services/dockercleaner install and tests will be skipped
 EOF
 fi
 
+# Ensure we have the newest selenium-webdriver
+gem update selenium-webdriver
+
+# If DISPLAY is unset, there is no way selenium/firefox could work
+if [ -n "${DISPLAY}" ]
+then
+    # Sanity check that selenium/firefox is actually working
+    ruby `dirname "$(readlink -f "$0")"`/selenium-firefox-sanity-check.rb
+    if [ "0" = "$?" ]
+    then
+	echo "Selenium appears to be working"
+    else
+	skip[apps/workbench]=1
+	cat >&2 <<EOF
+
+Warning: Selenium::WebDriver firefox driver not functional.
+apps/workbench install and tests will be skipped.
+
+EOF
+    fi
+else
+    cat >&2 <<EOF
+
+Warning: DISPLAY not set, Selenium::WebDriver cannot function.
+apps/workbench install and tests will be skipped.
+Suggest starting Xvfb and setting DISPLAY.
+
+EOF
+fi
+
 checkexit() {
     if [[ "$1" != "0" ]]; then
         title "!!!!!! $2 FAILED !!!!!!"

--- a/jenkins/selenium-firefox-sanity-check.html
+++ b/jenkins/selenium-firefox-sanity-check.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Selenium-Firefox Test</title>
+  </head>
+  <body>
+    <h1 id="test">Selenium-Firefox Test</h1>
+  </body>
+</html>

--- a/jenkins/selenium-firefox-sanity-check.rb
+++ b/jenkins/selenium-firefox-sanity-check.rb
@@ -1,0 +1,30 @@
+require "selenium-webdriver"
+
+test_uri = "file://" + File.expand_path(File.dirname(__FILE__) + "/selenium-firefox-sanity-check.html")
+
+# Initialize firefox driver
+begin
+  driver = Selenium::WebDriver.for :firefox
+rescue
+  STDERR.puts "Selenium::WebDriver could not initialize firefox driver"
+  exit 1
+end
+
+# Navigate to test file
+begin
+  driver.navigate.to test_uri
+rescue
+  STDERR.puts "Selenium::WebDriver firefox driver could not navigate to test page " + test_uri
+  exit 2
+end
+
+# Verify that Selenium can find an element in test file
+begin
+  element = driver.find_element(:id, 'test')
+rescue
+  STDERR.puts "Selenium::WebDriver firefox driver could not find element in test page"
+  exit 3
+end
+
+driver.quit
+exit 0


### PR DESCRIPTION
Adds two sanity checks to `jenkins/run-tests.sh`:
1. if DISPLAY env var is set (Selenium::WebDriver :firefox cannot function without it, so it isn't even worth checking)
2. that Selenium::WebDriver :firefox has at least basic functionality (navigate to a `file:` URI and find an element in the page by id)

If either fails, the `apps/workbench` tests will be skipped and a warning message printed. 

In my hands, these sanity checks save ~8 hours in the case when there is no X server running. 
