### PR TITLE
Alternative fix for 7308

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -478,16 +478,7 @@ do_test_once() {
         then
             covername="coverage-$(echo "$1" | sed -e 's/\//_/g')"
             coverflags=("-covermode=count" "-coverprofile=$WORKSPACE/tmp/.$covername.tmp")
-            if [[ -n "${testargs[$1]}" ]]
-            then
-                # "go test -check.vv giturl" doesn't work, but this
-                # does:
-                cd "$WORKSPACE/$1" && go test ${coverflags[@]} ${testargs[$1]}
-            else
-                # The above form gets verbose even when testargs is
-                # empty, so use this form in such cases:
-                go test ${coverflags[@]} "git.curoverse.com/arvados.git/$1"
-            fi
+	    go test -v ${coverflags[@]} "git.curoverse.com/arvados.git/$1" -check.v ${testargs[$1]}
             result="$?"
             go tool cover -html="$WORKSPACE/tmp/.$covername.tmp" -o "$WORKSPACE/tmp/$covername.html"
             rm "$WORKSPACE/tmp/.$covername.tmp"


### PR DESCRIPTION
Makes `go test` moderately verbose by default (can still be overridden for extreme verbosity by, for example, passing `services/arv-git-httpd_test="-check.vv"` to run-tests.sh). 
